### PR TITLE
Do not throw if PowerShell prints nothing to stdout

### DIFF
--- a/src/main/java/dev/dirs/Util.java
+++ b/src/main/java/dev/dirs/Util.java
@@ -198,7 +198,6 @@ final class Util {
     try {
       for (int i = 0; i < expectedResultLines; i++) {
         String line = reader.readLine();
-        if (line == null) throw new IOException("no output from process");
         if (i == 0 && operatingSystem == 'w' && line != null && line.startsWith(UTF8_BOM))
           line = line.substring(UTF8_BOM.length());
         results[i] = line;


### PR DESCRIPTION
This is a workaround for https://github.com/dirs-dev/directories-jvm/issues/43. It restores the behaviour prior to https://github.com/dirs-dev/directories-jvm/pull/40 if the PowerShell is in Constrained Language mode.