### PR TITLE
Fallback to normal powershell if attempt downgrade fail, fixes #47

### DIFF
--- a/src/main/java/dev/dirs/Util.java
+++ b/src/main/java/dev/dirs/Util.java
@@ -222,14 +222,29 @@ final class Util {
         File commandFile = new File(dir, command);
         if (commandFile.exists()) {
           try {
-            return runCommands(guidsLength, Charset.forName("UTF-8"),
-                commandFile.toString(),
-                "-version",
-                "2",
-                "-NoProfile",
-                "-EncodedCommand",
-                encodedCommand
+            String[] stdout;
+            // try to run using powershell V2 to bypass constrained language mode
+            // note that this has been deprecated in new version of Windows
+            // https://devblogs.microsoft.com/powershell/windows-powershell-2-0-deprecation/
+            // for some set up, running this requires installation of extra dependency on Windows host
+            stdout = runCommands(guidsLength, Charset.forName("UTF-8"),
+                    commandFile.toString(),
+                    "-version",
+                    "2",
+                    "-NoProfile",
+                    "-EncodedCommand",
+                    encodedCommand
             );
+            if (stdout[0] != null) return stdout;
+
+            // fall-forward to higher version of powershell
+            stdout = runCommands(guidsLength, Charset.forName("UTF-8"),
+                    commandFile.toString(),
+                    "-NoProfile",
+                    "-EncodedCommand",
+                    encodedCommand
+            );
+            return stdout;
           } catch (IOException e) {
             firstException = firstException == null ? e : firstException;
           }

--- a/src/test/java/dev/dirs/UtilTest.java
+++ b/src/test/java/dev/dirs/UtilTest.java
@@ -2,8 +2,11 @@ package dev.dirs;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static dev.dirs.Util.getWinDirs;
+import static org.junit.Assert.*;
 
 public final class UtilTest {
 
@@ -179,4 +182,11 @@ public final class UtilTest {
     }
   }
 
+  @Test
+  public void testPowershell() {
+    if (Util.operatingSystem == 'w') {
+      String[] winDirs = getWinDirs("3EB685DB-65F9-4CF6-A03A-E3EF65729F3D", "F1B32785-6FBA-4FCF-9D55-7B8E7F157091");
+      assertTrue(Arrays.stream(winDirs).allMatch(Objects::nonNull));
+    }
+  }
 }


### PR DESCRIPTION
Powershell running with "-version 2" to bypass Constrained Language Mode
sometimes fail on newer version of windows due to lack of dependency.
In such cases, the error message is printed to stderr instead and
output from reader is always null

This fix tries to recover from such failure by attempting to run with
default (higher) version of powershell. If that still fails then the
input is the same as of previous version where all elements of the array
is null