### PR TITLE
Add IBM i as supported platform

### DIFF
--- a/src/main/java/dev/dirs/BaseDirectories.java
+++ b/src/main/java/dev/dirs/BaseDirectories.java
@@ -251,6 +251,7 @@ public final class BaseDirectories {
       case LIN:
       case BSD:
       case SOLARIS:
+      case IBMI:
         homeDir       = System.getProperty("user.home");
         cacheDir      = defaultIfNullOrEmpty(System.getenv("XDG_CACHE_HOME"),  homeDir, "/.cache");
         configDir     = defaultIfNullOrEmpty(System.getenv("XDG_CONFIG_HOME"), homeDir, "/.config");

--- a/src/main/java/dev/dirs/ProjectDirectories.java
+++ b/src/main/java/dev/dirs/ProjectDirectories.java
@@ -234,6 +234,7 @@ public final class ProjectDirectories {
       case LIN:
       case BSD:
       case SOLARIS:
+      case IBMI:
         homeDir       = System.getProperty("user.home");
         cacheDir      = defaultIfNullOrEmptyExtended(System.getenv("XDG_CACHE_HOME"),  path, homeDir + "/.cache/",       path);
         configDir     = defaultIfNullOrEmptyExtended(System.getenv("XDG_CONFIG_HOME"), path, homeDir + "/.config/",      path);

--- a/src/main/java/dev/dirs/UserDirectories.java
+++ b/src/main/java/dev/dirs/UserDirectories.java
@@ -327,6 +327,18 @@ public final class UserDirectories {
         templateDir   = null;
         videoDir      = homeDir + "/Movies";
         break;
+      case IBMI:
+        homeDir       = System.getProperty("user.home");
+        audioDir      = homeDir + "/Music";
+        desktopDir    = homeDir + "/Desktop";
+        documentDir   = homeDir + "/Documents";
+        downloadDir   = homeDir + "/Downloads";
+        fontDir       = defaultIfNullOrEmptyExtended(System.getenv("XDG_DATA_HOME"), "/fonts",  homeDir, "/.local/share/fonts");
+        pictureDir    = homeDir + "/Pictures";
+        publicDir     = homeDir + "/Public";
+        templateDir   = null;
+        videoDir      = homeDir + "/Movies";
+        break;
       case WIN:
         String[] winDirs = getWinDirs(
             "5E6C858F-0E22-4760-9AFE-EA3317B67173",

--- a/src/main/java/dev/dirs/Util.java
+++ b/src/main/java/dev/dirs/Util.java
@@ -22,6 +22,7 @@ final class Util {
   static final char WIN = 'w';
   static final char BSD = 'b';
   static final char SOLARIS = 's';
+  static final char IBMI = 'i';
 
   static final String UTF8_BOM = "\ufeff";
 
@@ -37,6 +38,8 @@ final class Util {
       operatingSystem = BSD;
     else if (os.contains("sunos"))
       operatingSystem = SOLARIS;
+    else if (os.contains("os/400") || os.contains("os400"))
+      operatingSystem = IBMI;
     else
       throw new UnsupportedOperatingSystemException("directories are not supported on " + operatingSystemName);
   }


### PR DESCRIPTION

Contribution adds IBM i as a supported platform

Sample values on IBM i
```
base dirs
BaseDirectories (OS/400):
  homeDir       = '/home/MYUSER'
  cacheDir      = '/home/MYUSER/.cache'
  configDir     = '/home/MYUSER/.config'
  dataDir       = '/home/MYUSER/.local/share'
  dataLocalDir  = '/home/MYUSER/.local/share'
  executableDir = '/home/MYUSER/.local/share/../bin/'
  preferenceDir = '/home/MYUSER/.config'
  runtimeDir    = 'null'



proj dirs
ProjectDirectories (OS/400):
  projectPath   = 'COURSIER'
  cacheDir      = '/home/MYUSER/.cache/COURSIER'
  configDir     = '/home/MYUSER/.config/COURSIER'
  dataDir       = '/home/MYUSER/.local/share/COURSIER'
  dataLocalDir  = '/home/MYUSER/.local/share/COURSIER'
  preferenceDir = '/home/MYUSER/.config/COURSIER'
  runtimeDir    = 'null'



user dirs
UserDirectories (OS/400):
  homeDir     = '/home/MYUSER'
  audioDir    = '/home/MYUSER/Music'
  fontDir     = '/home/MYUSER/.local/share/fonts'
  desktopDir  = '/home/MYUSER/Desktop'
  documentDir = '/home/MYUSER/Documents'
  downloadDir = '/home/MYUSER/Downloads'
  pictureDir  = '/home/MYUSER/Pictures'
  publicDir   = '/home/MYUSER/Public'
  templateDir = 'null'
  videoDir    = '/home/MYUSER/Movies'
```
Without this change, https://github.com/sbt/sbt fails with
```
[info] [launcher] getting org.scala-sbt sbt 1.5.0  (this may take some time)...
[error] [launcher] java.lang.ExceptionInInitializerError
[error] [launcher] could not retrieve sbt 1.5.0
```

Resolves https://github.com/sbt/sbt/issues/6435 