### PR TITLE
Increase project directories support for IBM i

### DIFF
--- a/src/main/java/dev/dirs/ProjectDirectories.java
+++ b/src/main/java/dev/dirs/ProjectDirectories.java
@@ -296,6 +296,7 @@ public final class ProjectDirectories {
       case LIN:
       case BSD:
       case SOLARIS:
+      case IBMI:
       case AIX:
         path = trimLowercaseReplaceWhitespace(application, "", true);
         break;


### PR DESCRIPTION
I do not know IBM i, but I think that maybe a line may be missing in commit 51645dff42406cd70fd29b5a678daf91291d822d for full support of project directories.

As we should prefer method `from` over `fromPath`, this may be a useful addition. IBM i is probably very Unix-like with regards to how the `from` method should work on it, so the same approach as for Solaris, Linux, etc. should be fine I guess.